### PR TITLE
refactor: clarify annotation types to support sparse (#2296)

### DIFF
--- a/jina/drivers/index.py
+++ b/jina/drivers/index.py
@@ -39,9 +39,27 @@ class VectorIndexDriver(BaseIndexDriver):
     If `method` is not 'delete', documents without content are filtered out.
     """
 
-    @staticmethod
-    def _get_documents_embeddings(docs: 'DocumentSet'):
-        return docs.all_embeddings
+    @property
+    def exec_embedding_cls_type(self) -> str:
+        """Get the sparse class type of the attached executor.
+
+        :return: Embedding class type of the attached executor, default value is `dense`
+        """
+        return self.exec.embedding_cls_type
+
+    def _get_documents_embeddings(self, docs: 'DocumentSet'):
+        embedding_cls_type = self.exec_embedding_cls_type
+        if embedding_cls_type == 'dense':
+            return docs.all_embeddings
+        else:
+            scipy_cls_type = None
+            if embedding_cls_type.startswith('scipy'):
+                scipy_cls_type = embedding_cls_type.split('_')[1]
+                embedding_cls_type = 'scipy'
+
+            return docs.get_all_sparse_embeddings(
+                sparse_cls_type=embedding_cls_type, scipy_cls_type=scipy_cls_type
+            )
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
         embed_vecs, docs_pts = self._get_documents_embeddings(docs)
@@ -49,14 +67,6 @@ class VectorIndexDriver(BaseIndexDriver):
             keys = [doc.id for doc in docs_pts]
             self.check_key_length(keys)
             self.exec_fn(keys, embed_vecs)
-
-
-class SparseVectorIndexDriver(VectorIndexDriver):
-    """An alias to have coherent naming with the required SparseVectorSearchDriver """
-
-    @staticmethod
-    def _get_documents_embeddings(docs: 'DocumentSet'):
-        return docs.all_sparse_embeddings
 
 
 class KVIndexDriver(BaseIndexDriver):

--- a/jina/drivers/search.py
+++ b/jina/drivers/search.py
@@ -121,18 +121,47 @@ class VectorSearchDriver(FlatRecursiveMixin, QuerySetReader, BaseSearchDriver):
         self._top_k = top_k
         self._fill_embedding = fill_embedding
 
-    @staticmethod
-    def _get_documents_embeddings(docs: 'DocumentSet'):
-        return docs.all_embeddings
+    @property
+    def exec_embedding_cls_type(self) -> str:
+        """Get the sparse class type of the attached executor.
 
-    @staticmethod
-    def _fill_matches(doc, op_name, topks, scores, topk_embed):
-        for numpy_match_id, score, vec in zip(topks, scores, topk_embed):
-            m = Document(id=numpy_match_id)
-            m.score = NamedScore(op_name=op_name, value=score)
-            r = doc.matches.append(m)
-            if vec is not None:
-                r.embedding = vec
+        :return: Embedding class type of the attached executor, default value is `dense`.
+        """
+        return self.exec.embedding_cls_type
+
+    def _get_documents_embeddings(self, docs: 'DocumentSet'):
+        embedding_cls_type = self.exec_embedding_cls_type
+        if embedding_cls_type == 'dense':
+            return docs.all_embeddings
+        else:
+            scipy_cls_type = None
+            if embedding_cls_type.startswith('scipy'):
+                scipy_cls_type = embedding_cls_type.split('_')[1]
+                embedding_cls_type = 'scipy'
+
+            return docs.get_all_sparse_embeddings(
+                sparse_cls_type=embedding_cls_type, scipy_cls_type=scipy_cls_type
+            )
+
+    def _fill_matches(self, doc, op_name, topks, scores, topk_embed):
+        embedding_cls_type = self.exec_embedding_cls_type
+        if embedding_cls_type == 'dense':
+            for numpy_match_id, score, vector in zip(topks, scores, topk_embed):
+                m = Document(id=numpy_match_id)
+                m.score = NamedScore(op_name=op_name, value=score)
+                r = doc.matches.append(m)
+                if vector is not None:
+                    r.embedding = vector
+        else:
+            for idx, (numpy_match_id, score) in enumerate(zip(topks, scores)):
+                vector = None
+                if topk_embed is not None:
+                    vector = topk_embed.getrow(idx)
+                m = Document(id=numpy_match_id)
+                m.score = NamedScore(op_name=op_name, value=score)
+                match = doc.matches.append(m)
+                if vector:
+                    match.embedding = vector
 
     def _apply_all(self, docs: 'DocumentSet', *args, **kwargs) -> None:
         embed_vecs, doc_pts = self._get_documents_embeddings(docs)
@@ -155,23 +184,3 @@ class VectorSearchDriver(FlatRecursiveMixin, QuerySetReader, BaseSearchDriver):
                 else [None] * len(topks)
             )
             self._fill_matches(doc, op_name, topks, scores, topk_embed)
-
-
-class SparseVectorSearchDriver(VectorSearchDriver):
-    """
-    Extract sparse embeddings from the request for the executor to query.
-    """
-
-    @staticmethod
-    def _get_documents_embeddings(docs: 'DocumentSet'):
-        return docs.all_sparse_embeddings
-
-    @staticmethod
-    def _fill_matches(doc, op_name, topks, scores, topk_embed):
-        for id, (numpy_match_id, score) in enumerate(zip(topks, scores)):
-            vec = topk_embed.getrow(id)
-            m = Document(id=numpy_match_id)
-            m.score = NamedScore(op_name=op_name, value=score)
-            r = doc.matches.append(m)
-            if vec is not None:
-                r.embedding = vec

--- a/jina/executors/encoders/__init__.py
+++ b/jina/executors/encoders/__init__.py
@@ -4,11 +4,25 @@ __license__ = "Apache-2.0"
 from typing import Any
 
 from .. import BaseExecutor
-from ..compound import CompoundExecutor
 
 if False:
     # fix type-hint complain for sphinx and flake
+    from typing import TypeVar
     import numpy as np
+    import scipy
+    import tensorflow as tf
+    import torch
+
+    EncodingType = TypeVar(
+        'EncodingType',
+        np.ndarray,
+        scipy.sparse.csr_matrix,
+        scipy.sparse.coo_matrix,
+        scipy.sparse.bsr_matrix,
+        scipy.sparse.csc_matrix,
+        torch.sparse_coo_tensor,
+        tf.SparseTensor,
+    )
 
 
 class BaseEncoder(BaseExecutor):
@@ -17,10 +31,10 @@ class BaseEncoder(BaseExecutor):
     The key function is :func:`encode`.
 
     .. seealso::
-        :mod:`jina.drivers.handlers.encode`
+        :mod:`jina.drivers.encode`
     """
 
-    def encode(self, data: Any, *args, **kwargs) -> Any:
+    def encode(self, data: Any, *args, **kwargs) -> 'EncodingType':
         """Encode the data, needs to be implemented in subclass.
         :param data: the data to be encoded
         :param args: additional positional arguments
@@ -33,7 +47,7 @@ class BaseEncoder(BaseExecutor):
 class BaseNumericEncoder(BaseEncoder):
     """BaseNumericEncoder encodes data from a ndarray, potentially B x ([T] x D) into a ndarray of B x D"""
 
-    def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
+    def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'EncodingType':
         """
         :param data: a `B x ([T] x D)` numpy ``ndarray``, `B` is the size of the batch
         :param args: additional positional arguments
@@ -65,7 +79,7 @@ class BaseTextEncoder(BaseEncoder):
     BaseTextEncoder encodes data from an array of string type (data.dtype.kind == 'U') of size B into a ndarray of B x D.
     """
 
-    def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'np.ndarray':
+    def encode(self, data: 'np.ndarray', *args, **kwargs) -> 'EncodingType':
         """
 
         :param data: an 1d array of string type (data.dtype.kind == 'U') in size B

--- a/jina/executors/indexers/__init__.py
+++ b/jina/executors/indexers/__init__.py
@@ -10,6 +10,23 @@ from .. import BaseExecutor
 from ..compound import CompoundExecutor
 from ...helper import call_obj_fn, cached_property, get_readable_size
 
+if False:
+    from typing import TypeVar
+    import scipy
+    import tensorflow as tf
+    import torch
+
+    EncodingType = TypeVar(
+        'EncodingType',
+        np.ndarray,
+        scipy.sparse.csr_matrix,
+        scipy.sparse.coo_matrix,
+        scipy.sparse.bsr_matrix,
+        scipy.sparse.csc_matrix,
+        torch.sparse_coo_tensor,
+        tf.SparseTensor,
+    )
+
 
 class BaseIndexer(BaseExecutor):
     """Base class for storing and searching any kind of data structure.
@@ -249,6 +266,8 @@ class BaseVectorIndexer(BaseIndexer):
     It can be used to tell whether an indexer is vector indexer, via ``isinstance(a, BaseVectorIndexer)``
     """
 
+    embedding_cls_type = 'dense'
+
     def query_by_key(self, keys: Iterable[str], *args, **kwargs) -> 'np.ndarray':
         """Get the vectors by id, return a subset of indexed vectors
 
@@ -258,7 +277,9 @@ class BaseVectorIndexer(BaseIndexer):
         """
         raise NotImplementedError
 
-    def add(self, keys: Iterable[str], vectors: 'np.ndarray', *args, **kwargs) -> None:
+    def add(
+        self, keys: Iterable[str], vectors: 'EncodingType', *args, **kwargs
+    ) -> None:
         """Add new chunks and their vector representations
 
         :param keys: a list of ``id``, i.e. ``doc.id`` in protobuf
@@ -269,7 +290,7 @@ class BaseVectorIndexer(BaseIndexer):
         raise NotImplementedError
 
     def query(
-        self, vectors: 'np.ndarray', top_k: int, *args, **kwargs
+        self, vectors: 'EncodingType', top_k: int, *args, **kwargs
     ) -> Tuple['np.ndarray', 'np.ndarray']:
         """Find k-NN using query vectors, return chunk ids and chunk scores
 
@@ -281,7 +302,7 @@ class BaseVectorIndexer(BaseIndexer):
         raise NotImplementedError
 
     def update(
-        self, keys: Iterable[str], vectors: 'np.ndarray', *args, **kwargs
+        self, keys: Iterable[str], vectors: 'EncodingType', *args, **kwargs
     ) -> None:
         """Update vectors on the index.
 
@@ -300,10 +321,6 @@ class BaseVectorIndexer(BaseIndexer):
         :param kwargs: Additional keyword arguments
         """
         raise NotImplementedError
-
-
-class BaseSparseVectorIndexer(BaseVectorIndexer):
-    """ Alias to provide proper default drivers in resources"""
 
 
 class BaseKVIndexer(BaseIndexer):

--- a/jina/types/document/__init__.py
+++ b/jina/types/document/__init__.py
@@ -7,7 +7,7 @@ import urllib.parse
 import urllib.request
 import warnings
 from hashlib import blake2b
-from typing import Union, Dict, Optional, TypeVar, Any, Tuple, List
+from typing import Union, Dict, Optional, TypeVar, Any, Tuple, List, Type
 
 import numpy as np
 from google.protobuf import json_format
@@ -16,7 +16,7 @@ from google.protobuf.field_mask_pb2 import FieldMask
 from .traversable import Traversable
 from .converters import png_to_buffer, to_datauri, guess_mime, to_image_blob
 from ..mixin import ProtoTypeMixin
-from ..ndarray.generic import NdArray
+from ..ndarray.generic import NdArray, BaseSparseNdArray
 from ..querylang.queryset.dunderkey import dunder_get
 from ..score import NamedScore
 from ..sets.chunk import ChunkSet
@@ -29,6 +29,35 @@ from ...proto import jina_pb2
 
 if False:
     from scipy.sparse import coo_matrix
+
+    # fix type-hint complain for sphinx and flake
+    from typing import TypeVar
+    import numpy as np
+    import scipy
+    import tensorflow as tf
+    import torch
+
+    EmbeddingType = TypeVar(
+        'EncodingType',
+        np.ndarray,
+        scipy.sparse.csr_matrix,
+        scipy.sparse.coo_matrix,
+        scipy.sparse.bsr_matrix,
+        scipy.sparse.csc_matrix,
+        torch.sparse_coo_tensor,
+        tf.SparseTensor,
+    )
+
+    SparseEmbeddingType = TypeVar(
+        'SparseEmbeddingType',
+        np.ndarray,
+        scipy.sparse.csr_matrix,
+        scipy.sparse.coo_matrix,
+        scipy.sparse.bsr_matrix,
+        scipy.sparse.csc_matrix,
+        torch.sparse_coo_tensor,
+        tf.SparseTensor,
+    )
 
 __all__ = ['Document', 'DocumentContentType', 'DocumentSourceType']
 DIGEST_SIZE = 8
@@ -470,20 +499,30 @@ class Document(ProtoTypeMixin, Traversable):
         self._update_ndarray('blob', value)
 
     @property
-    def embedding(self) -> 'np.ndarray':
+    def embedding(self) -> 'EmbeddingType':
         """Return ``embedding`` of the content of a Document.
 
         :return: the embedding from the proto
         """
         return NdArray(self._pb_body.embedding).value
 
-    @property
-    def sparse_embedding(self) -> 'coo_matrix':
+    def get_sparse_embedding(
+        self, sparse_ndarray_cls_type: Type[BaseSparseNdArray], **kwargs
+    ) -> 'SparseEmbeddingType':
         """Return ``embedding`` of the content of a Document as an sparse array.
 
+        :param sparse_ndarray_cls_type: Sparse class type, such as `SparseNdArray`.
+        :param kwargs: Additional key value argument, for `scipy` backend, we need to set
+            the keyword `sp_format` as one of the scipy supported sparse format, such as `coo`
+            or `csr`.
         :return: the embedding from the proto as an sparse array
         """
-        return NdArray(self._pb_body.embedding, is_sparse=True).value
+        return NdArray(
+            self._pb_body.embedding,
+            sparse_cls=sparse_ndarray_cls_type,
+            is_sparse=True,
+            **kwargs,
+        ).value
 
     @embedding.setter
     def embedding(self, value: Union['np.ndarray', 'jina_pb2.NdArrayProto', 'NdArray']):
@@ -572,7 +611,7 @@ class Document(ProtoTypeMixin, Traversable):
         else:
             v_valid_sparse_type = self._update_if_sparse(k, v)
 
-            if v_valid_sparse_type == False:
+            if not v_valid_sparse_type:
                 raise TypeError(f'{k} is in unsupported type {typename(v)}')
 
     @property

--- a/jina/types/ndarray/generic.py
+++ b/jina/types/ndarray/generic.py
@@ -114,7 +114,7 @@ class NdArray(BaseNdArray):
         if stype == 'dense':
             return self.dense_cls(self._pb_body.dense).value
         elif stype == 'sparse':
-            return self.sparse_cls(self._pb_body.sparse).value
+            return self.sparse_cls(self._pb_body.sparse, **self._kwargs).value
 
     @value.setter
     def value(self, value):

--- a/tests/integration/sparse_pipeline/indexer.yml
+++ b/tests/integration/sparse_pipeline/indexer.yml
@@ -4,8 +4,8 @@ requests:
     ControlRequest:
       - !ControlReqDriver {}
     SearchRequest:
-      - !SparseVectorSearchDriver
+      - !VectorSearchDriver
         with:
           fill_embedding: True
     IndexRequest:
-    - !SparseVectorIndexDriver {}
+    - !VectorIndexDriver {}

--- a/tests/integration/sparse_pipeline/test_sparse_pipeline.py
+++ b/tests/integration/sparse_pipeline/test_sparse_pipeline.py
@@ -8,7 +8,7 @@ from scipy import sparse
 from jina import Flow, Document
 from jina.types.sets import DocumentSet
 from jina.executors.encoders import BaseEncoder
-from jina.executors.indexers import BaseSparseVectorIndexer
+from jina.executors.indexers import BaseVectorIndexer
 
 from tests import validate_callback
 
@@ -38,27 +38,29 @@ class DummySparseEncoder(BaseEncoder):
         return embed
 
 
-class DummyCSRSparseIndexer(BaseSparseVectorIndexer):
+class DummyCSRSparseIndexer(BaseVectorIndexer):
+    embedding_cls_type = 'scipy_csr'
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.keys = []
         self.vectors = {}
 
     def add(
-        self, keys: Iterable[str], vectors: 'scipy.sparse.coo_matrix', *args, **kwargs
+        self, keys: Iterable[str], vectors: 'scipy.sparse.csr_matrix', *args, **kwargs
     ) -> None:
-        assert isinstance(vectors, sparse.coo_matrix)
+        assert isinstance(vectors, sparse.csr_matrix)
         self.keys.extend(keys)
         for i, key in enumerate(keys):
             self.vectors[key] = vectors.getrow(i)
 
-    def query(self, vectors: 'scipy.sparse.coo_matrix', top_k: int, *args, **kwargs):
-        assert isinstance(vectors, sparse.coo_matrix)
+    def query(self, vectors: 'scipy.sparse.csr_matrix', top_k: int, *args, **kwargs):
+        assert isinstance(vectors, sparse.csr_matrix)
         distances = [item for item in range(0, min(top_k, len(self.keys)))]
         return [self.keys[:top_k]], np.array([distances])
 
     def query_by_key(self, keys: Iterable[str], *args, **kwargs):
-        from scipy.sparse import coo_matrix, vstack
+        from scipy.sparse import vstack
 
         vectors = []
         for key in keys:

--- a/tests/unit/drivers/test_vector_index_driver.py
+++ b/tests/unit/drivers/test_vector_index_driver.py
@@ -11,6 +11,9 @@ from jina.executors.indexers import BaseVectorIndexer
 from jina.types.document import Document
 
 
+# TODO: Add tests for sparse vectors index driver.
+
+
 class MockGroundTruthVectorIndexer(BaseVectorIndexer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/unit/drivers/test_vector_search_driver.py
+++ b/tests/unit/drivers/test_vector_search_driver.py
@@ -7,6 +7,8 @@ from jina import Document, QueryLang
 from jina.drivers.search import VectorSearchDriver
 from jina.executors.indexers import BaseVectorIndexer
 
+# TODO: Add tests for sparse vectors search driver.
+
 
 class MockVectorSearchDriver(VectorSearchDriver):
     @property


### PR DESCRIPTION
* refactor: clarify annotation types to support sparse

* feat: proposal to generalize to multiple sparse types

* feat: add sparse cls type property

* feat: clean up search deriver

* feat: clean up search deriver

* feat: add docstring and hints for all sparse emebdfdings

* feat: add docstring and hints for all sparse emebdfdings

* feat: apply black format

* feat: fix docstring and format

Co-authored-by: bwanglzu <bo.wang@jina.ai>