### PR TITLE
fix: seek body file when computing _start (#2980)

### DIFF
--- a/jina/types/arrays/memmap.py
+++ b/jina/types/arrays/memmap.py
@@ -104,6 +104,7 @@ class DocumentArrayMemmap(TraversableSequence, DocumentArrayGetAttrMixin, Itr):
         self._start = 0
         if self._header_map:
             self._start = tmp[-1][1] + tmp[-1][3]
+            self._body.seek(self._start)
 
     def __len__(self):
         return len(self._header_map)

--- a/tests/unit/types/arrays/test_memmap.py
+++ b/tests/unit/types/arrays/test_memmap.py
@@ -173,3 +173,21 @@ def test_convert_dm_to_dam(tmpdir, mocker):
     mock.assert_called()
     assert len(da) == 0
     assert len(dam) == 100
+
+
+@pytest.mark.parametrize('embed_dim', [10, 10000])
+def test_extend_and_get_attribute(tmpdir, embed_dim):
+    dam = DocumentArrayMemmap(tmpdir)
+    docs = list(random_docs(100, start_id=0, embed_dim=embed_dim))
+    dam.extend(docs)
+
+    dam2 = DocumentArrayMemmap(tmpdir)
+    x = dam2.get_attributes('embedding')
+    assert len(dam2) == 100
+
+    docs = list(random_docs(100, start_id=100, embed_dim=embed_dim))
+    dam2.extend(docs)
+    x = dam2.get_attributes('embedding')
+    assert len(x) == 200
+    assert x[0].shape == (embed_dim,)
+    assert len(dam2) == 200


### PR DESCRIPTION
* fix: seek body file when computing _start

* test: convert script and add to test

* chore: check embedding in test_memmap

Co-authored-by: felix-wang <35718120+numb3r3@users.noreply.github.com>

Co-authored-by: winstonww <winstonwongww2@gmail.com>
Co-authored-by: felix-wang <35718120+numb3r3@users.noreply.github.com>